### PR TITLE
Add zoom functionality.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+Add `zoom` function, based on the implementation in `robrix/starlight`. (:tophat: to Rob.)
+
 # v1.2.0.0
 
 Introduce `?=` and `<~`.


### PR DESCRIPTION
This is based on @robrix's work in `starlight`, but is generalized to
return any type, not just `()`.